### PR TITLE
fix: small typo in tech used

### DIFF
--- a/dogconfig/dogproject/templates/UI/_about.html
+++ b/dogconfig/dogproject/templates/UI/_about.html
@@ -39,7 +39,7 @@
         <li><a href='https://github.com/django/django/blob/master/LICENSE'>django</a></li>
         <li><a href='https://www.django-rest-framework.org/#license'>django-rest-framework</a></li>
         <li><a href='https://github.com/SeleniumHQ/selenium/blob/trunk/LICENSE'>Selenium WebDriver Python bindings</a></li>
-        <li><a href='https://github.com/memcached/memcached/blob/master/LICENSE'>memecache</a></li>
+        <li><a href='https://github.com/memcached/memcached/blob/master/LICENSE'>memcached</a></li>
     </ul>
 </div>
 {% endblock content %}


### PR DESCRIPTION
Fix typo on memcached in the list of technology used.